### PR TITLE
fix: remove serviceaccount of main controller of ls instances

### DIFF
--- a/internal/installer/landscaper/deployment_main.go
+++ b/internal/installer/landscaper/deployment_main.go
@@ -56,7 +56,6 @@ func (m *mainDeploymentMutator) Mutate(r *appsv1.Deployment) error {
 				AutomountServiceAccountToken: ptr.To(false),
 				Volumes:                      m.volumes(),
 				Containers:                   m.containers(),
-				ServiceAccountName:           m.landscaperFullName(),
 				SecurityContext:              m.values.PodSecurityContext,
 				ImagePullSecrets:             m.values.ImagePullSecrets,
 				TopologySpreadConstraints:    m.controllerMainComponent.TopologySpreadConstraints(),


### PR DESCRIPTION
**What this PR does / why we need it**:

The service provider landscaper creates for each landscaper instance several Deployments (helm-deployer, manifest-deployer, landscaper-controller, landscaper-controller-main, landscaper-webhooks-server). The Pods of the `landscaper-controller-main` Deployment did not start, because the referenced ServiceAccount does not exist. This PR fixes this, by removing the ServiceAccount ref from the `landscaper-controller-main` Deployment/Pods.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
- Fixes the issue that the main controller of landscaper instances did not start.
```
