### PR TITLE
feat: add crd manifests to component

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -14,3 +14,5 @@ includes:
       REPO_URL: 'https://github.com/openmcp-project/service-provider-landscaper'
       GENERATE_DOCS_INDEX: "true"
       CHART_COMPONENTS: "[]"
+      CRDS_COMPONENTS: 'service-provider-landscaper'
+      CRDS_PATH: '{{.ROOT_DIR}}/api/crds/manifests'


### PR DESCRIPTION
**What this PR does / why we need it**:

Add CRD manifests to OCM component so that they can be deployed statically by the openMCP bootstrapper.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Add CRD manifests to OCM component
```
