### PR TITLE
chore: align phase status field values

### DIFF
--- a/api/v1alpha2/landscaper_types.go
+++ b/api/v1alpha2/landscaper_types.go
@@ -25,9 +25,9 @@ import (
 type LandscaperPhase string
 
 const (
-	PhaseProgressing LandscaperPhase = "PhaseProgressing"
-	PhaseTerminating LandscaperPhase = "PhaseTerminating"
-	PhaseReady       LandscaperPhase = "PhaseReady"
+	PhaseProgressing LandscaperPhase = "Progressing"
+	PhaseTerminating LandscaperPhase = "Terminating"
+	PhaseReady       LandscaperPhase = "Ready"
 
 	ConditionTypeInstalled   = "Installed"
 	ConditionTypeUninstalled = "Uninstalled"


### PR DESCRIPTION
**What this PR does / why we need it**:

Aling the the values of the status phase field to match with other service providers:

* `PhaseReady` -> `Ready`
* `PhaseProgressing` -> `Progressing`
* `PhaseTerminating` -> `PhaseTerminating`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
Align status phase field values with the service provider standard
```
