### PR TITLE
chore: rename API group to landscaper.services.open-control-plane.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The Service Provider Landscaper requires a `ProviderConfig` resource to be prese
 This resource defines the container image repository and the available versions of the Landscaper instances that can be installed.
 
 ```yaml
-apiVersion: landscaper.services.openmcp.cloud/v1alpha2
+apiVersion: landscaper.services.open-control-plane.io/v1alpha2
 kind: ProviderConfig
 metadata:
   name: default
@@ -36,7 +36,7 @@ An OpenMCP user can request a Landscaper instance by creating a custom resource 
 For example, let's suppose an OpenMCP user has already created a `ManagedControlPlane` resource with name `sample` in namespace `project-x--workspace-y`. The user could then create the following `Landscaper` resource to use the MCP together with a Landscaper instance:
 
 ```yaml
-apiVersion: landscaper.services.openmcp.cloud/v1alpha2
+apiVersion: landscaper.services.open-control-plane.io/v1alpha2
 kind: Landscaper
 metadata:
   name: sample
@@ -48,7 +48,7 @@ spec:
 If the Landscaper instance should use a specific provider configuration, the user can specify the name of the `ProviderConfig` resource in the `spec.providerConfigRef` field.
 
 ```yaml
-apiVersion: landscaper.services.openmcp.cloud/v1alpha2
+apiVersion: landscaper.services.open-control-plane.io/v1alpha2
 kind: Landscaper
 metadata:
   name: sample

--- a/api/crds/manifests/landscaper.services.open-control-plane.io_landscapers.yaml
+++ b/api/crds/manifests/landscaper.services.open-control-plane.io_landscapers.yaml
@@ -6,9 +6,9 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.20.1
   labels:
     openmcp.cloud/cluster: onboarding
-  name: landscapers.landscaper.services.openmcp.cloud
+  name: landscapers.landscaper.services.open-control-plane.io
 spec:
-  group: landscaper.services.openmcp.cloud
+  group: landscaper.services.open-control-plane.io
   names:
     kind: Landscaper
     listKind: LandscaperList

--- a/api/crds/manifests/landscaper.services.open-control-plane.io_providerconfigs.yaml
+++ b/api/crds/manifests/landscaper.services.open-control-plane.io_providerconfigs.yaml
@@ -6,9 +6,9 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.20.1
   labels:
     openmcp.cloud/cluster: platform
-  name: providerconfigs.landscaper.services.openmcp.cloud
+  name: providerconfigs.landscaper.services.open-control-plane.io
 spec:
-  group: landscaper.services.openmcp.cloud
+  group: landscaper.services.open-control-plane.io
   names:
     kind: ProviderConfig
     listKind: ProviderConfigList

--- a/api/v1alpha2/groupversion_info.go
+++ b/api/v1alpha2/groupversion_info.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the  v1alpha1 API group.
 // +kubebuilder:object:generate=true
-// +groupName=landscaper.services.openmcp.cloud
+// +groupName=landscaper.services.open-control-plane.io
 package v1alpha2
 
 import (
@@ -27,7 +27,7 @@ import (
 
 var (
 	// GroupVersion is group version used to register these objects.
-	GroupVersion = schema.GroupVersion{Group: "landscaper.services.openmcp.cloud", Version: "v1alpha2"}
+	GroupVersion = schema.GroupVersion{Group: "landscaper.services.open-control-plane.io", Version: "v1alpha2"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
 	SchemeBuilder = runtime.NewSchemeBuilder(func(scheme *runtime.Scheme) error {

--- a/docs/resources/landscaper.yaml
+++ b/docs/resources/landscaper.yaml
@@ -1,4 +1,4 @@
-apiVersion: landscaper.services.openmcp.cloud/v1alpha1
+apiVersion: landscaper.services.open-control-plane.io/v1alpha1
 kind: Landscaper
 metadata:
   name: sample

--- a/docs/resources/overview.md
+++ b/docs/resources/overview.md
@@ -37,7 +37,7 @@ flowchart LR
 The `ProviderConfig` resource lives on the **platform cluster** and defines the container image registry and available versions for all Landscaper instances managed by the provider.
 
 ```yaml
-apiVersion: landscaper.services.openmcp.cloud/v1alpha2
+apiVersion: landscaper.services.open-control-plane.io/v1alpha2
 kind: ProviderConfig
 metadata:
   name: default
@@ -93,7 +93,7 @@ If the label `landscaper.services.openmcp.cloud/providertype: default` is set, t
 ## Landscaper Resource
 
 ```yaml
-apiVersion: landscaper.services.openmcp.cloud/v1alpha1
+apiVersion: landscaper.services.open-control-plane.io/v1alpha1
 kind: Landscaper
 metadata:
   name: sample
@@ -150,7 +150,7 @@ Next the user has to create a Landscaper resource with the name <name> and names
 ```shell
 
 ```yaml
-apiVersion: landscaper.services.openmcp.cloud/v1alpha1
+apiVersion: landscaper.services.open-control-plane.io/v1alpha1
 kind: Landscaper
 metadata:
   name: <name>

--- a/internal/controller/testdata/test-01/landscaper.yaml
+++ b/internal/controller/testdata/test-01/landscaper.yaml
@@ -1,4 +1,4 @@
-apiVersion: landscaper.services.openmcp.cloud/v1alpha2
+apiVersion: landscaper.services.open-control-plane.io/v1alpha2
 kind: Landscaper
 metadata:
   name: test

--- a/internal/controller/testdata/test-01/providerconfig.yaml
+++ b/internal/controller/testdata/test-01/providerconfig.yaml
@@ -1,4 +1,4 @@
-apiVersion: landscaper.services.openmcp.cloud/v1alpha2
+apiVersion: landscaper.services.open-control-plane.io/v1alpha2
 kind: ProviderConfig
 metadata:
   labels:

--- a/internal/controller/testdata/test-02/landscaper.yaml
+++ b/internal/controller/testdata/test-02/landscaper.yaml
@@ -1,4 +1,4 @@
-apiVersion: landscaper.services.openmcp.cloud/v1alpha2
+apiVersion: landscaper.services.open-control-plane.io/v1alpha2
 kind: Landscaper
 metadata:
   name: test

--- a/internal/controller/testdata/test-02/providerconfig.yaml
+++ b/internal/controller/testdata/test-02/providerconfig.yaml
@@ -1,4 +1,4 @@
-apiVersion: landscaper.services.openmcp.cloud/v1alpha2
+apiVersion: landscaper.services.open-control-plane.io/v1alpha2
 kind: ProviderConfig
 metadata:
   name: test

--- a/internal/controller/testdata/test-03/landscaper.yaml
+++ b/internal/controller/testdata/test-03/landscaper.yaml
@@ -1,4 +1,4 @@
-apiVersion: landscaper.services.openmcp.cloud/v1alpha2
+apiVersion: landscaper.services.open-control-plane.io/v1alpha2
 kind: Landscaper
 metadata:
   name: test

--- a/internal/controller/testdata/test-03/providerconfig.yaml
+++ b/internal/controller/testdata/test-03/providerconfig.yaml
@@ -1,4 +1,4 @@
-apiVersion: landscaper.services.openmcp.cloud/v1alpha2
+apiVersion: landscaper.services.open-control-plane.io/v1alpha2
 kind: ProviderConfig
 metadata:
   labels:

--- a/internal/installer/helmdeployer/testdata/test-01/providerconfig.yaml
+++ b/internal/installer/helmdeployer/testdata/test-01/providerconfig.yaml
@@ -1,4 +1,4 @@
-apiVersion: landscaper.services.openmcp.cloud/v1alpha2
+apiVersion: landscaper.services.open-control-plane.io/v1alpha2
 kind: ProviderConfig
 metadata:
   labels:

--- a/internal/installer/instance/testdata/test-01/providerconfig.yaml
+++ b/internal/installer/instance/testdata/test-01/providerconfig.yaml
@@ -1,4 +1,4 @@
-apiVersion: landscaper.services.openmcp.cloud/v1alpha2
+apiVersion: landscaper.services.open-control-plane.io/v1alpha2
 kind: ProviderConfig
 metadata:
   labels:

--- a/internal/installer/landscaper/testdata/test-01/providerconfig.yaml
+++ b/internal/installer/landscaper/testdata/test-01/providerconfig.yaml
@@ -1,4 +1,4 @@
-apiVersion: landscaper.services.openmcp.cloud/v1alpha2
+apiVersion: landscaper.services.open-control-plane.io/v1alpha2
 kind: ProviderConfig
 metadata:
   labels:

--- a/internal/installer/manifestdeployer/testdata/test-01/providerconfig.yaml
+++ b/internal/installer/manifestdeployer/testdata/test-01/providerconfig.yaml
@@ -1,4 +1,4 @@
-apiVersion: landscaper.services.openmcp.cloud/v1alpha2
+apiVersion: landscaper.services.open-control-plane.io/v1alpha2
 kind: ProviderConfig
 metadata:
   labels:

--- a/internal/installer/rbac/testdata/test-01/providerconfig.yaml
+++ b/internal/installer/rbac/testdata/test-01/providerconfig.yaml
@@ -1,4 +1,4 @@
-apiVersion: landscaper.services.openmcp.cloud/v1alpha1
+apiVersion: landscaper.services.open-control-plane.io/v1alpha1
 kind: ProviderConfig
 metadata:
   labels:


### PR DESCRIPTION
**What this PR does / why we need it**:
Rename the Kubernetes API group domain from `landscaper.services.openmcp.cloud` to `landscaper.services.open-control-plane.io`.

Updated files:
- `api/*/groupversion_info.go`: `+groupName` marker and `GroupVersion.Group` constant
- `internal/`: kubebuilder RBAC markers
- `test/`: e2e test fixtures and Go test files
- `docs/`, `README.md`, `config/`: documentation and sample manifests
- Regenerated via `task generate`: CRD manifests, RBAC roles, deepcopy functions

**Which issue(s) this PR fixes**:
Part of https://github.com/openmcp-project/backlog/issues/533

**Special notes for your reviewer**:
Only the exact full API group string is replaced. Go files are classified by claude to distinguish API group references (replaced) from label/annotation key constants (left unchanged). `pkg/` and `cmd/` are excluded entirely. CRD manifests and RBAC roles are fully regenerated via `task generate`.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Renamed Kubernetes API group from `landscaper.services.openmcp.cloud` to `landscaper.services.open-control-plane.io`.
```