### PR TITLE
chore: group openmcp-project/build renovate updates into one PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -35,6 +35,14 @@
       "rebaseWhen": "auto",
       "minimumReleaseAge": "0 days",
       "enabled": true
+    },
+    {
+      "description": "Group openmcp-project/build submodule and workflow updates",
+      "matchDepNames": [
+        "hack/common",
+        "openmcp-project/build"
+      ],
+      "groupName": "openmcp-project/build"
     }
   ]
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a Renovate `matchDepNames` entry that groups the `hack/common` git submodule and `openmcp-project/build` to prevent Renovate from creating two separate PRs per build update.

**Which issue(s) this PR fixes**:
https://github.com/openmcp-project/backlog/issues/563

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
