### PR TITLE
docs: add Quality Criteria self-assessment to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,16 @@
 
 [![Quality: Incubating](https://img.shields.io/badge/Quality-Incubating-3d9970?style=flat-square&labelColor=555)](https://open-control-plane.io/developers/serviceprovider/quality-criteria)
 
-| Criterion                         | Status  | Notes                                                                                                          |
-| --------------------------------- | :----:  | -------------------------------------------------------------------------------------------------------------- |
-| Deletion behaviour                |   ⚠️    | Finalizer is wired up; blocking deletion when Landscaper-managed CRs still exist is not verified.              |
-| Status reporting & error messages |   ✅    |                                                                                                                |
-| Operation annotations             |   ❌    | `openmcp.cloud/operation` (pause / force-reconcile) annotations are not honoured.                              |
-| API stability policy              |   ✅    |                                                                                                                |
-| Custom CA support                 |   ❌    | Custom CA bundle propagation to Landscaper components is not implemented.                                      |
-| Release artifacts (image + OCM)   |   ✅    |                                                                                                                |
-| Testing                           |   ⚠️    | Unit and envtest suites exist; full lifecycle tests against a real cluster are not present.                    |
-| Ownership and maintenance docs    |   ✅    |                                                                                                                |
+| Criterion                         | Status  | Notes                                                                                                                                                                                                                                                            |
+| --------------------------------- | :----:  | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Deletion behaviour                |   ⚠️    | A finalizer ensures the Service Provider managed resources like `Deployments` etc. But there is no behaviour that ensures deletion is blocked if custom resources (e.g. Landscaper' `Installation` objects) in a `ControlPlane` still exist.                     |
+| Status reporting & error messages |   ✅    |                                                                                                                                                                                                                                                                  |
+| Operation annotations             |   ❌    | `openmcp.cloud/operation` (pause / force-reconcile) annotations are not honoured.                                                                                                                                                                                |
+| API stability policy              |   ✅    |                                                                                                                                                                                                                                                                  |
+| Custom CA support                 |   ❌    | Custom CA bundle propagation to Landscaper components is not implemented.                                                                                                                                                                                        |
+| Release artifacts (image + OCM)   |   ✅    |                                                                                                                                                                                                                                                                  |
+| Testing                           |   ⚠️    | Unit and envtest suites exist; full lifecycle tests against a real cluster are not present.                                                                                                                                                                      |
+| Ownership and maintenance docs    |   ✅    |                                                                                                                                                                                                                                                                  |
 
 See the [OpenControlPlane Quality Criteria](https://open-control-plane.io/developers/serviceprovider/quality-criteria) for definitions.
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,23 @@
 
 # Service Provider Landscaper
 
+## Quality Criteria
+
+[![Quality: Incubating](https://img.shields.io/badge/Quality-Incubating-3d9970?style=flat-square&labelColor=555)](https://open-control-plane.io/developers/serviceprovider/quality-criteria)
+
+| Criterion                         | Status  | Notes                                                                                                          |
+| --------------------------------- | :----:  | -------------------------------------------------------------------------------------------------------------- |
+| Deletion behaviour                |   ⚠️    | Finalizer is wired up; blocking deletion when Landscaper-managed CRs still exist is not verified.              |
+| Status reporting & error messages |   ✅    |                                                                                                                |
+| Operation annotations             |   ❌    | `openmcp.cloud/operation` (pause / force-reconcile) annotations are not honoured.                              |
+| API stability policy              |   ✅    |                                                                                                                |
+| Custom CA support                 |   ❌    | Custom CA bundle propagation to Landscaper components is not implemented.                                      |
+| Release artifacts (image + OCM)   |   ✅    |                                                                                                                |
+| Testing                           |   ⚠️    | Unit and envtest suites exist; full lifecycle tests against a real cluster are not present.                    |
+| Ownership and maintenance docs    |   ✅    |                                                                                                                |
+
+See the [OpenControlPlane Quality Criteria](https://open-control-plane.io/developers/serviceprovider/quality-criteria) for definitions.
+
 ## About this project
 
 Service Provider Landscaper manages the lifecycle of Landscaper instances.

--- a/README.md
+++ b/README.md
@@ -6,16 +6,16 @@
 
 [![Quality: Incubating](https://img.shields.io/badge/Quality-Incubating-3d9970?style=flat-square&labelColor=555)](https://open-control-plane.io/developers/serviceprovider/quality-criteria)
 
-| Criterion                         | Status  | Notes                                                                                                                                                                                                                                                            |
-| --------------------------------- | :----:  | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Deletion behaviour                |   ⚠️    | A finalizer ensures the Service Provider managed resources like `Deployments` etc. But there is no behaviour that ensures deletion is blocked if custom resources (e.g. Landscaper' `Installation` objects) in a `ControlPlane` still exist.                     |
-| Status reporting & error messages |   ✅    |                                                                                                                                                                                                                                                                  |
-| Operation annotations             |   ❌    | `openmcp.cloud/operation` (pause / force-reconcile) annotations are not honoured.                                                                                                                                                                                |
-| API stability policy              |   ✅    |                                                                                                                                                                                                                                                                  |
-| Custom CA support                 |   ❌    | Custom CA bundle propagation to Landscaper components is not implemented.                                                                                                                                                                                        |
-| Release artifacts (image + OCM)   |   ✅    |                                                                                                                                                                                                                                                                  |
-| Testing                           |   ⚠️    | Unit and envtest suites exist; full lifecycle tests against a real cluster are not present.                                                                                                                                                                      |
-| Ownership and maintenance docs    |   ✅    |                                                                                                                                                                                                                                                                  |
+| Criterion                         | Status | Notes                                                                                                                                                                                                                                        |
+| --------------------------------- | :----: | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Deletion behaviour                |   ⚠️    | A finalizer ensures the Service Provider managed resources like `Deployments` etc. are cleaned-up. But there is no behaviour that ensures deletion is blocked if custom resources (e.g. Landscaper' `Installation` objects) in a `ControlPlane` still exist. |
+| Status reporting & error messages |   ✅    |                                                                                                                                                                                                                                              |
+| Operation annotations             |   ❌    | `openmcp.cloud/operation` (pause / force-reconcile) annotations are not honoured.                                                                                                                                                            |
+| API stability policy              |   ✅    |                                                                                                                                                                                                                                              |
+| Custom CA support                 |   ❌    | Custom CA bundle propagation to Landscaper components is not implemented.                                                                                                                                                                    |
+| Release artifacts (image + OCM)   |   ✅    |                                                                                                                                                                                                                                              |
+| Testing                           |   ⚠️    | Unit and envtest suites exist; full lifecycle tests against a real cluster are not present.                                                                                                                                                  |
+| Ownership and maintenance docs    |   ✅    |                                                                                                                                                                                                                                              |
 
 See the [OpenControlPlane Quality Criteria](https://open-control-plane.io/developers/serviceprovider/quality-criteria) for definitions.
 
@@ -25,7 +25,7 @@ Service Provider Landscaper manages the lifecycle of Landscaper instances.
 
 ### Provider Configuration
 
-The Service Provider Landscaper requires a `ProviderConfig` resource to be present on the platform cluster of an OpenMCP landscape. 
+The Service Provider Landscaper requires a `ProviderConfig` resource to be present on the platform cluster of an OpenMCP landscape.
 This resource defines the container image repository and the available versions of the Landscaper instances that can be installed.
 
 ```yaml
@@ -37,10 +37,10 @@ metadata:
     landscaper.services.openmcp.cloud/providertype: default
 spec:
   deployment:
-    repository: ghcr.io/openmcp-project/components 
+    repository: ghcr.io/openmcp-project/components
     availableVersions:
       - v1.1.0
-      - v1.1.0 
+      - v1.1.0
 ```
 
 If the label `landscaper.services.openmcp.cloud/providertype` is set to `default`, the Service Provider Landscaper will automatically use this `ProviderConfig` resource.
@@ -85,7 +85,7 @@ The Service Provider Landscaper runs on the platform cluster of an OpenMCP lands
 
 ```mermaid
 flowchart LR
-    
+
     subgraph Platform
         provider[Landscaper Provider]
     end

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Service Provider Landscaper manages the lifecycle of Landscaper instances.
 
 ### Provider Configuration
 
-The Service Provider Landscaper requires a `ProviderConfig` resource to be present on the platform cluster of an OpenMCP landscape.
+The Service Provider Landscaper requires a `ProviderConfig` resource to be present on the platform cluster of an OpenControlPlane landscape.
 This resource defines the container image repository and the available versions of the Landscaper instances that can be installed.
 
 ```yaml
@@ -31,9 +31,9 @@ The default provider configuration will be used by all Landscaper instances that
 
 ### Requesting a Landscaper
 
-An OpenMCP user can request a Landscaper instance by creating a custom resource of kind `Landscaper` on the onboarding cluster of an OpenMCP landscape. A prerequisite is that the user has already created an `ManagedControlPlane` (MCP). Both resources, `ManagedControlPlane` and `Landscaper`, must have the same name and namespace.
+An OpenControlPlane user can request a Landscaper instance by creating a custom resource of kind `Landscaper` on the onboarding cluster of an OpenControlPlane landscape. A prerequisite is that the user has already created an `ManagedControlPlane` (MCP). Both resources, `ManagedControlPlane` and `Landscaper`, must have the same name and namespace.
 
-For example, let's suppose an OpenMCP user has already created a `ManagedControlPlane` resource with name `sample` in namespace `project-x--workspace-y`. The user could then create the following `Landscaper` resource to use the MCP together with a Landscaper instance:
+For example, let's suppose an OpenControlPlane user has already created a `ManagedControlPlane` resource with name `sample` in namespace `project-x--workspace-y`. The user could then create the following `Landscaper` resource to use the MCP together with a Landscaper instance:
 
 ```yaml
 apiVersion: landscaper.services.open-control-plane.io/v1alpha2
@@ -64,7 +64,7 @@ The Service Provider Landscaper will then install a Landscaper instance together
 
 ### Architecture Overview
 
-The Service Provider Landscaper runs on the platform cluster of an OpenMCP landscape. It reconciles `Landscaper` resources and installs the corresponding Landscaper instances. Each Landscaper installed in this way runs on a so-called workload cluster and reconciles `Installation` resources on the MCP cluster.
+The Service Provider Landscaper runs on the platform cluster of an OpenControlPlane landscape. It reconciles `Landscaper` resources and installs the corresponding Landscaper instances. Each Landscaper installed in this way runs on a so-called workload cluster and reconciles `Installation` resources on the MCP cluster.
 
 ```mermaid
 flowchart LR
@@ -96,7 +96,7 @@ flowchart LR
 
 ## Requirements and Setup
 
-The setup of the Service Provider Landscaper  within an OpenMCP landscape is described in: [Installing the Service Provider Landscaper](docs/technical/install.md).
+The setup of the Service Provider Landscaper  within an OpenControlPlane landscape is described in: [Installing the Service Provider Landscaper](docs/technical/install.md).
 
 ## Quality Criteria
 

--- a/README.md
+++ b/README.md
@@ -2,23 +2,6 @@
 
 # Service Provider Landscaper
 
-## Quality Criteria
-
-[![Quality: Incubating](https://img.shields.io/badge/Quality-Incubating-3d9970?style=flat-square&labelColor=555)](https://open-control-plane.io/developers/serviceprovider/quality-criteria)
-
-| Criterion                         | Status | Notes                                                                                                                                                                                                                                        |
-| --------------------------------- | :----: | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Deletion behaviour                |   ⚠️    | A finalizer ensures the Service Provider managed resources like `Deployments` etc. are cleaned-up. But there is no behaviour that ensures deletion is blocked if custom resources (e.g. Landscaper' `Installation` objects) in a `ControlPlane` still exist. |
-| Status reporting & error messages |   ✅    |                                                                                                                                                                                                                                              |
-| Operation annotations             |   ❌    | `openmcp.cloud/operation` (pause / force-reconcile) annotations are not honoured.                                                                                                                                                            |
-| API stability policy              |   ✅    |                                                                                                                                                                                                                                              |
-| Custom CA support                 |   ❌    | Custom CA bundle propagation to Landscaper components is not implemented.                                                                                                                                                                    |
-| Release artifacts (image + OCM)   |   ✅    |                                                                                                                                                                                                                                              |
-| Testing                           |   ⚠️    | Unit and envtest suites exist; full lifecycle tests against a real cluster are not present.                                                                                                                                                  |
-| Ownership and maintenance docs    |   ✅    |                                                                                                                                                                                                                                              |
-
-See the [OpenControlPlane Quality Criteria](https://open-control-plane.io/developers/serviceprovider/quality-criteria) for definitions.
-
 ## About this project
 
 Service Provider Landscaper manages the lifecycle of Landscaper instances.
@@ -111,10 +94,26 @@ flowchart LR
     landscaper_controller -- reconciles --> installation
 ```
 
-
 ## Requirements and Setup
 
 The setup of the Service Provider Landscaper  within an OpenMCP landscape is described in: [Installing the Service Provider Landscaper](docs/technical/install.md).
+
+## Quality Criteria
+
+[![Quality: Incubating](https://img.shields.io/badge/Quality-Incubating-3d9970?style=flat-square&labelColor=555)](https://open-control-plane.io/developers/serviceprovider/quality-criteria)
+
+| Criterion                         | Status | Notes                                                                                                                                                                                                                                                        |
+| --------------------------------- | :----: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Deletion behaviour                |   ⚠️    | A finalizer ensures the Service Provider managed resources like `Deployments` etc. are cleaned-up. But there is no behaviour that ensures deletion is blocked if custom resources (e.g. Landscaper' `Installation` objects) in a `ControlPlane` still exist. |
+| Status reporting & error messages |   ✅    |                                                                                                                                                                                                                                                              |
+| Operation annotations             |   ⚠️    | `landscaper.services.openmcp.cloud/operation: reconcile` is processed. `openmcp.cloud/operation: ignore` is not processed.                                                                                                                                   |
+| API stability policy              |   ✅    |                                                                                                                                                                                                                                                              |
+| Custom CA support                 |   ❌    | Custom CA bundle propagation to Landscaper components is not implemented.                                                                                                                                                                                    |
+| Release artifacts (image + OCM)   |   ✅    |                                                                                                                                                                                                                                                              |
+| Testing                           |   ⚠️    | Unit and envtest suites exist; full lifecycle tests against a real cluster are not present.                                                                                                                                                                  |
+| Ownership and maintenance docs    |   ✅    |                                                                                                                                                                                                                                                              |
+
+See the [OpenControlPlane Quality Criteria](https://open-control-plane.io/developers/serviceprovider/quality-criteria) for definitions.
 
 ## Support, Feedback, Contributing
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds the [Quality Criteria](https://open-control-plane.io/developers/serviceprovider/quality-criteria) block (tier badge + self-assessment table + link) to the README.

**Which issue(s) this PR fixes**:
Refs openmcp-project/docs#49

**Special notes for your reviewer**:
README-only change.

**Release note**:
```doc developer
Add Quality Criteria self-assessment block to the README.
```