### PR TITLE
chore(deps): removes renovate config which is in org presets

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,46 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>openmcp-project/.github:renovate-config",
-    ":enableVulnerabilityAlerts"
-  ],
-  "git-submodules": {
-    "enabled": true
-  },
-  "minimumReleaseAge": "0 days",
-  "packageRules": [
-    {
-      "matchPackageNames": [
-        "github.com/openmcp-project/*"
-      ],
-      "description": "Update all components from openmcp-project and landscaper immediately",
-      "rebaseWhen": "auto",
-      "minimumReleaseAge": "0 days",
-      "automerge": true,
-      "enabled": true
-    },
-    {
-      "description": "Automerge submodule update",
-      "automerge": true,
-      "matchPackageNames": ["hack/common"]
-    },
-    {
-      "description": "Update and automerge all components from openmcp-project immediately in one single PR",
-      "matchManagers": [
-        "gomod"
-      ],
-      "groupName": "openmcp-project Go dependencies",
-      "groupSlug": "openmcp-go-deps",
-      "automerge": true,
-      "automergeType": "pr",
-      "prPriority": 10,
-      "semanticCommitType": "chore",
-      "rebaseWhen": "auto",
-      "minimumReleaseAge": "0 days",
-      "enabled": true,
-      "matchPackageNames": [
-        "/^github.com/openmcp-project//"
-      ]
-    }
+    "github>openmcp-project/.github:renovate-config"
   ]
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

removes renovate config which is in new org-level preset

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```other dependency

```